### PR TITLE
Fix Unicode parameter names in user auth

### DIFF
--- a/app/src/main/java/com/example/apppresupuesto/data/dao/UsuarioDao.kt
+++ b/app/src/main/java/com/example/apppresupuesto/data/dao/UsuarioDao.kt
@@ -9,8 +9,8 @@ interface UsuarioDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertar(usuario: Usuario): Long
 
-    @Query("SELECT * FROM usuarios WHERE email = :email AND contraseña = :contraseña LIMIT 1")
-    suspend fun login(email: String, contraseña: String): Usuario?
+    @Query("SELECT * FROM usuarios WHERE email = :email AND contrasena = :contrasena LIMIT 1")
+    suspend fun login(email: String, contrasena: String): Usuario?
 
     @Query("SELECT * FROM usuarios WHERE id = :id")
     suspend fun obtenerPorId(id: Int): Usuario?

--- a/app/src/main/java/com/example/apppresupuesto/data/entities/Usuario.kt
+++ b/app/src/main/java/com/example/apppresupuesto/data/entities/Usuario.kt
@@ -7,5 +7,5 @@ import androidx.room.PrimaryKey
 data class Usuario(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val email: String,
-    val contraseña: String // Puedes luego encriptar esto
+    val contrasena: String // Puedes luego encriptar esto
 )

--- a/app/src/main/java/com/example/apppresupuesto/data/repository/UsuarioRepository.kt
+++ b/app/src/main/java/com/example/apppresupuesto/data/repository/UsuarioRepository.kt
@@ -9,8 +9,8 @@ class UsuarioRepository(private val usuarioDao: UsuarioDao) {
         return usuarioDao.insertar(usuario)
     }
 
-    suspend fun login(email: String, contraseña: String): Usuario? {
-        return usuarioDao.login(email, contraseña)
+    suspend fun login(email: String, contrasena: String): Usuario? {
+        return usuarioDao.login(email, contrasena)
     }
 
     suspend fun obtenerPorId(id: Int): Usuario? {

--- a/app/src/main/java/com/example/apppresupuesto/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/example/apppresupuesto/ui/screens/LoginScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.*
 import androidx.compose.ui.text.input.*
 import androidx.compose.ui.unit.dp
 import com.example.apppresupuesto.viewmodel.SesionViewModel
-import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun LoginScreen(
@@ -16,7 +15,7 @@ fun LoginScreen(
     onLoginSuccess: () -> Unit
 ) {
     var email by remember { mutableStateOf("") }
-    var contraseña by remember { mutableStateOf("") }
+    var contrasena by remember { mutableStateOf("") }
     var esRegistro by remember { mutableStateOf(false) }
 
     val error by sesionViewModel.error.collectAsState()
@@ -53,8 +52,8 @@ fun LoginScreen(
         Spacer(modifier = Modifier.height(12.dp))
 
         OutlinedTextField(
-            value = contraseña,
-            onValueChange = { contraseña = it },
+            value = contrasena,
+            onValueChange = { contrasena = it },
             label = { Text("Contraseña") },
             modifier = Modifier.fillMaxWidth(),
             visualTransformation = PasswordVisualTransformation(),
@@ -66,9 +65,9 @@ fun LoginScreen(
         Button(
             onClick = {
                 if (esRegistro) {
-                    sesionViewModel.registrar(email, contraseña)
+                    sesionViewModel.registrar(email, contrasena)
                 } else {
-                    sesionViewModel.login(email, contraseña)
+                    sesionViewModel.login(email, contrasena)
                 }
             },
             modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/com/example/apppresupuesto/viewmodel/SesionViewModel.kt
+++ b/app/src/main/java/com/example/apppresupuesto/viewmodel/SesionViewModel.kt
@@ -18,9 +18,9 @@ class SesionViewModel(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error
 
-    fun login(email: String, contraseña: String) {
+    fun login(email: String, contrasena: String) {
         viewModelScope.launch {
-            val usuario = usuarioRepository.login(email, contraseña)
+            val usuario = usuarioRepository.login(email, contrasena)
             if (usuario != null) {
                 _usuarioActual.value = usuario
                 _error.value = null
@@ -30,9 +30,9 @@ class SesionViewModel(
         }
     }
 
-    fun registrar(email: String, contraseña: String) {
+    fun registrar(email: String, contrasena: String) {
         viewModelScope.launch {
-            val nuevoUsuario = Usuario(email = email, contraseña = contraseña)
+            val nuevoUsuario = Usuario(email = email, contrasena = contrasena)
             val id = usuarioRepository.insertar(nuevoUsuario)
             _usuarioActual.value = nuevoUsuario.copy(id = id.toInt())
             _error.value = null


### PR DESCRIPTION
## Summary
- rename `contraseña` column/params to `contrasena`
- clean up `LoginScreen` to use the new field and remove unused import

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635f06ce0483229366ac3d00890bcb